### PR TITLE
Build MAM4 with CAMP: Latest changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,7 @@ add_subdirectory(libraries)
 include_directories("${PROJECT_BINARY_DIR}")
 include_directories("${PROJECT_BINARY_DIR}/include")
 link_directories("${PROJECT_BINARY_DIR}/lib")
+link_directories("${PROJECT_BINARY_DIR}/lib64")
 
 # the box models
 add_subdirectory(mam4)

--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -279,7 +279,11 @@ if (ENABLE_CAMP)
     JSON_FORTRAN_HOME=${CMAKE_BINARY_DIR}
     SUNDIALS_HOME=${CMAKE_BINARY_DIR}
   )
-  ExternalProject_Add(camp
+  # next couple lines added by D. Quevedo: Jan 29 2025
+  add_library(camp SHARED IMPORTED GLOBAL)
+  set_target_properties(camp PROPERTIES
+        IMPORTED_LOCATION ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}/libcamp.so)
+  ExternalProject_Add(camp_proj
     PREFIX ${CMAKE_CURRENT_BINARY_DIR}/camp
     DOWNLOAD_DIR ${CMAKE_SOURCE_DIR}/downloads
     DOWNLOAD_NAME camp.zip
@@ -312,7 +316,7 @@ if (ENABLE_CAMP)
     -DKLU_LIBRARY_DIR=${CMAKE_BINARY_DIR}/lib
     -DKLU_INCLUDE_DIR=${CMAKE_BINARY_DIR}/include
   )
-  ExternalProject_Add_Step(camp build-cvode
+  ExternalProject_Add_Step(camp_proj build-cvode
     COMMENT "Building CAMP-specific CVODE..."
     COMMAND cmake -E tar xfz ${CAMP_CVODE_TARBALL}
     COMMAND cmake -S ${CAMP_CVODE_SOURCE_DIR} -B ${CAMP_CVODE_BUILD_DIR} ${CAMP_CVODE_CMAKE_ARGS}
@@ -338,7 +342,7 @@ if (ENABLE_CAMP)
       DEPENDERS configure # CAMP must be configured after this step
     )
   endif()
-  ExternalProject_Add_Step(camp relocate-camp-headers
+  ExternalProject_Add_Step(camp_proj relocate-camp-headers
     COMMENT "Copying CAMP headers to where PartMC can find them..."
     COMMAND cmake -E copy_directory ${CMAKE_BINARY_DIR}/include/camp ${CMAKE_BINARY_DIR}/include
     LOG TRUE

--- a/mam4/CMakeLists.txt
+++ b/mam4/CMakeLists.txt
@@ -64,10 +64,19 @@ add_executable(mam4
   ${MAM4_SOURCE_DIR}/test_drivers/driver.F90
   ${MAM4_SOURCE_DIR}/box_model_utils/main.F90
 )
-target_link_libraries(mam4 netcdff netcdf hdf5_hl hdf5 dl z)
+if(ENABLE_CAMP)
+    target_link_libraries(mam4 camp netcdff netcdf hdf5_hl hdf5 dl z)
+    set_target_properties(mam4 PROPERTIES
+        BUILD_RPATH "${CMAKE_BINARY_DIR}/lib;${CMAKE_BINARY_DIR}/lib64")
+else()
+    target_link_libraries(mam4 netcdff netcdf hdf5_hl hdf5 dl z)
+endif()
 
 # These macros are defined in ${MAM4_SOURCE_DIR}/test_drivers/cambox_config.cpp.in.
 target_compile_definitions(mam4 PRIVATE CAMBOX_ACTIVATE_THIS;CAMBOX_DEACTIVATE_THIS;MODAL_AERO;MODAL_AERO_4MODE_MOM;RAIN_EVAP_TO_COARSE_AERO;PCNST=35;PCOLS=1;PVER=1;NBC=1;NPOA=1;NSOA=1)
+if (ENABLE_CAMP)
+  add_definitions(-DMAM4_USE_CAMP)
+endif()
 
 install(
   TARGETS mam4

--- a/mam4/CMakeLists.txt
+++ b/mam4/CMakeLists.txt
@@ -67,7 +67,8 @@ add_executable(mam4
 if(ENABLE_CAMP)
     target_link_libraries(mam4 camp netcdff netcdf hdf5_hl hdf5 dl z)
     set_target_properties(mam4 PROPERTIES
-        BUILD_RPATH "${CMAKE_BINARY_DIR}/lib;${CMAKE_BINARY_DIR}/lib64")
+        BUILD_RPATH "${CMAKE_BINARY_DIR}/lib;${CMAKE_BINARY_DIR}/lib64"
+        INSTALL_RPATH "${CMAKE_BINARY_DIR}/lib;${CMAKE_BINARY_DIR}/lib64")
 else()
     target_link_libraries(mam4 netcdff netcdf hdf5_hl hdf5 dl z)
 endif()


### PR DESCRIPTION
Additions and modifications to link CAMP with MAM4. Currently clones MAM_box_model_dq for CAMP coupling, which is not yet pulled into MAM_box_model.